### PR TITLE
Table list set full width by default and hoverable effect

### DIFF
--- a/backoffice_extensions/templates/backoffice/bases/list.html
+++ b/backoffice_extensions/templates/backoffice/bases/list.html
@@ -20,7 +20,7 @@
   <hr />
   <div class="columns">
     <div class="column table-container">
-      <table class="table">
+      <table class="table is-fullwidth is-hoverable">
         <thead>
           <tr>
             {% for field in list_display %}


### PR DESCRIPTION
Add to default list view full with and hoverable effect.

![Screenshot 2020-07-16 at 14 46 57](https://user-images.githubusercontent.com/1159690/87672431-3f933580-c773-11ea-9925-d1e6788c7310.png)
