### PR TITLE
Mark required fields with a *

### DIFF
--- a/backoffice_extensions/templates/backoffice/bases/form.html
+++ b/backoffice_extensions/templates/backoffice/bases/form.html
@@ -12,7 +12,7 @@
   {% else  %}
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <label class="label">{{ field.label }}</label>
+      <label class="label">{{ field.label }} {% if field.field.required %}*{% endif %}</label>
     </div>
     <div class="field-body">
       <div class="field">


### PR DESCRIPTION
The interface should give a hint to the users if a field is required in the form.

In this PR a `*` has been added next to the field if the field is required.