### PR TITLE
Alineado consistente de datos en la vista de detalle

### DIFF
--- a/backoffice_extensions/templates/backoffice/bases/detail.html
+++ b/backoffice_extensions/templates/backoffice/bases/detail.html
@@ -16,19 +16,25 @@
             </div>
         </div>
         <hr>
-        <div class="columns">
-            <div class="column">
-                <table class="table is-fullwidth">
-                    {% for field in fields %}
-                        <tr>
-                            <th class="is-capitalized">{{ instance|verbose_name:field }}</th>
-                            <td>{{ instance|getattr:field }}</td>
-                        </tr>
-                    {% endfor %}
-                </table>
+        {% for field in fields %}
+            <div class="columns is-gapless is-0 mt-2 mb-2">
+                <div class="column">
+                    <strong class="is-capitalized">{{ instance|verbose_name:field }}</strong>
+                </div>
+                <div class="column is-three-quarters">
+                    {{ instance|getattr:field }}
+                </div>
             </div>
-        </div>
+            {% if not forloop.last %}
+                <div class="is-divider mt-0 mb-0"></div>
+            {% endif %}
+        {% endfor %}
     </div>
     {% block extra_content %}
     {% endblock extra_content %}
 {% endblock content %}
+
+
+{% block footer %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-divider@0.2.0/dist/css/bulma-divider.min.css">
+{% endblock %}


### PR DESCRIPTION
Actualmente en la vista de detalle se está utilizando una tabla para representar los datos. El problema que tiene esto es que la longitud de las columnas es variable dependiendo del nombre más campo del modelo. Ejemplos:

![image](https://user-images.githubusercontent.com/9640279/118312780-2c1b3d00-b4f2-11eb-9ed9-8e74d72033fd.png)
![image](https://user-images.githubusercontent.com/9640279/118312802-34737800-b4f2-11eb-8cb4-bc85392393da.png)

Además, el problema va más allá en el caso de que quieras añadir otra tabla similar usando una card similar a la del detalle para datos inlines:

![image](https://user-images.githubusercontent.com/9640279/118312933-68e73400-b4f2-11eb-9a51-c3cbe4edc096.png)

Con este cambio se propone migrar la tabla a las columnas responsive de bulma, obteniendo así tamaños consistentes entre todas las vistas. Además, para el separador que antes era el de las tablas, se ha utilizado una [extensión de bulma](https://wikiki.github.io/layout/divider/).

Resultado final:

![image](https://user-images.githubusercontent.com/9640279/118314160-07c06000-b4f4-11eb-9442-a286ce96ef0c.png)

Firmado: 
![image](https://user-images.githubusercontent.com/9640279/118314830-fa57a580-b4f4-11eb-90e2-17cd52aab30a.png)

