### PR TITLE
fix: sidebar groups permissions

### DIFF
--- a/backoffice_extensions/templatetags/backoffice.py
+++ b/backoffice_extensions/templatetags/backoffice.py
@@ -52,7 +52,11 @@ def sidebar_menu(context):
                         active,
                     )
                 )
-        sidebar.append((group_label, sections_data))
+
+        # If the group is empty skip it
+        if sections_data:
+            sidebar.append((group_label, sections_data))
+
     return {"sidebar": sidebar}
 
 


### PR DESCRIPTION
Si un grupo de la sidebar no tiene ningun item por tema de permisos o otro motivo, aparece vacio.

Actual:
![image](https://user-images.githubusercontent.com/9640279/118610807-73d4e980-b7bc-11eb-8ddb-e7e48ee93c20.png)

Con el cambio:
![image](https://user-images.githubusercontent.com/9640279/118610853-83543280-b7bc-11eb-9299-b5092ce1ad81.png)
