### PR TITLE
feat: add get_queryset to (almost) all base views

### DIFF
--- a/tests/backoffice/stuffs/views.py
+++ b/tests/backoffice/stuffs/views.py
@@ -23,3 +23,4 @@ class StuffDetailView(BackOfficeDetailView):
 
 class StuffDeleteView(BackOfficeDeleteView):
     model_class = Stuff
+    queryset = StuffListView.queryset


### PR DESCRIPTION
_Basado en DRF_

Actualmente de la única manera que podemos restringir el acceso en el backoffice es con permisos y en la vista de detalle/listado con una queryset. 

El problema de esto es que si hacemos el típico uso de meter en el queryset un filtro `accessible`, el listado quedaría filtrado pero el usuario podría vía URL seguir accediendo a los objetos si tiene el `ID`, mediante otras vistas (borrado y edición).

Con este cambio se trata de aportar granularidad además de seguridad al backoffice.

Además se ha optimizado el como se hacía uso del `get_objetct_or_404` en la vista de detalle, ya que se le puede pasar un `queryset` directamente. (ref: https://docs.djangoproject.com/en/3.2/topics/http/shortcuts/#get-object-or-404)